### PR TITLE
fix: [GITISSUE-18] ensure commitlint runs only on pull request events

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,7 @@ jobs:
         run: go build -o output/main .
 
   commitlint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Modify the commitlint job to execute exclusively during pull request events, improving efficiency in the CI process.