### PR TITLE
chore: [GITISSUE-21] add PR title linting action

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,24 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          subjectPattern: '^\[GITISSUE-\d+\] .+'
+          subjectPatternError: 'PR title must follows this example: fix: [GITISSUE-123] solve bug in feature xyz, feat: [GITISSUE-123] add feature xyz'
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce a GitHub Action to enforce a specific format for pull request titles, ensuring they start with a designated issue reference.